### PR TITLE
Update blueprints_update.sh source URL to SirGoodenough's repo.

### DIFF
--- a/blueprints_update.sh
+++ b/blueprints_update.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 self_file="$0"
-self_source_url="https://raw.githubusercontent.com/koter84/HomeAssistant_Blueprints_Update/main/blueprints_update.sh"
+self_source_url="https://raw.githubusercontent.com/SirGoodenough/Koter84_BP_Update/main/blueprints_update.sh" # Update URL to new repository.
 
 # defaults
 _do_update="false"


### PR DESCRIPTION
The original author, @koter84, has not been active on github since publishing the blueprints_update script in February '23 and the original repo appears to have been abandoned.

The change of the source URL reflects updating the script for any future changes to the forked branch, otherwise the fork will revert to the original repository, and not reload the automations, nor will it include future updates made by @SirGoodenough .